### PR TITLE
Robustify project root detection and VCD output path

### DIFF
--- a/build/builder.py
+++ b/build/builder.py
@@ -6,19 +6,25 @@ import sys
 
 # === STEP 0: Find MODEL_ROOT (project root) ===
 def find_model_root():
-    # Use environment variable if set
-    env_root = os.environ.get('MODEL_ROOT')
-    if env_root:
-        return os.path.abspath(env_root)
-    # Otherwise, walk up from current directory to find 'build' directory
-    cur = os.path.abspath(os.getcwd())
-    while cur != '/':
-        if os.path.isdir(os.path.join(cur, 'build')):
-            return cur
-        cur = os.path.dirname(cur)
-    raise RuntimeError("MODEL_ROOT not found (no 'build' directory in any parent)")
+    print("[DEBUG] Attempting to source source_me.sh to get MODEL_ROOT...")
+    try:
+        result = subprocess.check_output(
+            ['bash', '-c', 'source source_me.sh >/dev/null 2>&1 && echo $MODEL_ROOT'],
+            cwd=os.path.dirname(__file__)
+        )
+        model_root = result.decode('utf-8').strip()
+        print(f"[DEBUG] MODEL_ROOT from source_me.sh: '{model_root}'")
+        return model_root
+    except Exception as e:
+        print(f"[DEBUG] Exception while sourcing source_me.sh: {e}")
+        raise RuntimeError("MODEL_ROOT could not be determined by sourcing source_me.sh")
 
-MODEL_ROOT = find_model_root()
+try:
+    MODEL_ROOT = find_model_root()
+    print(f"[DEBUG] MODEL_ROOT set to: {MODEL_ROOT}")
+except Exception as e:
+    print(f"[DEBUG] Fatal error: {e}")
+    sys.exit(1)
 
 # === STEP 0.5: Get the project name from command-line arguments ===
 if len(sys.argv) < 2:

--- a/build/source_me.sh
+++ b/build/source_me.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
-# Set MODEL_ROOT to the directory containing this script's parent (the project root)
-export MODEL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Set MODEL_ROOT to the root of the current git repository
+MODEL_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$MODEL_ROOT" ]; then
+  echo "Error: Not inside a git repository."
+  return 1  # Use 'exit 1' if running as a script, 'return 1' if sourcing
+fi
+export MODEL_ROOT
 echo "MODEL_ROOT set to $MODEL_ROOT" 

--- a/verif/rf/tb_rf.sv
+++ b/verif/rf/tb_rf.sv
@@ -25,7 +25,7 @@ module rf_tb;
     always #5 clk = ~clk;
 
     initial begin
-        $dumpfile("../target/rf/rf.vcd");
+        $dumpfile("target/rf/rf.vcd");
         $dumpvars(0, rf_tb);
 
         /* ---------- reset values ---------- */


### PR DESCRIPTION
- build/source_me.sh: Use `git rev-parse --show-toplevel` to set MODEL_ROOT reliably in a git repo.
- build/builder.py: Always source `source_me.sh` to set MODEL_ROOT in Python, ensuring consistency with shell scripts. Add debug output for easier troubleshooting.
- verif/rf/tb_rf.sv: Fix $dumpfile path so VCD is written to the correct location for GTKWave.