### PR TITLE
compile correctly using -f file 

### DIFF
--- a/build/builder.py
+++ b/build/builder.py
@@ -72,36 +72,13 @@ def run_hw():
         print(f"❌ Missing file list: {F_FILE}")
         sys.exit(1)
 
-    # Parse file list for +incdir+ and source files
-    incdirs = []
-    srcfiles = []
-    with open(F_FILE, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith('#'):
-                continue
-            if line.startswith('+incdir+'):
-                # Make incdir absolute if not already
-                incdir = line[len('+incdir+'):]
-                if not os.path.isabs(incdir):
-                    incdir = os.path.join(MODEL_ROOT, incdir)
-                incdirs.append(incdir)
-            else:
-                # Make file path absolute if not already
-                src = line
-                if not os.path.isabs(src):
-                    src = os.path.join(MODEL_ROOT, src)
-                srcfiles.append(src)
-
+    # Use the -f flag to directly include the file list instead of parsing it manually
     compile_cmd = [
         "iverilog",
         "-g2012",
+        "-f", F_FILE,
+        "-o", os.path.join(TARGET_DIR, OUT_EXEC)
     ]
-    for incdir in incdirs:
-        compile_cmd += ["-I", incdir]
-    compile_cmd += ["-o", os.path.join(TARGET_DIR, OUT_EXEC)]
-    for src in srcfiles:
-        compile_cmd.append(src)
 
     print("Compile command:", " ".join(compile_cmd))  # Optional: for debugging
 


### PR DESCRIPTION
This pull request simplifies the `run_hw` function in `build/builder.py` by replacing manual parsing of a file list with the use of the `-f` flag in the `iverilog` command. This change reduces code complexity and leverages built-in functionality for handling file lists.

Code simplification:

* [`build/builder.py`](diffhunk://#diff-c04d92e06975804a1f416dd3f20d946de9a4e230bf62fb555848ac58903802b1L75-L104): Removed custom logic for parsing `+incdir+` and source file paths from the file list. Instead, the `-f` flag is used in the `iverilog` command to directly include the file list, simplifying the code and reducing potential errors.