### PR TITLE
add status in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # RTL Playground
 
+<!-- GitHub Actions Workflow Status -->
+![RTL_Build](https://github.com/benziongoldstein/playground_RTL/actions/workflows/build.yml/badge.svg?branch=master)
+
 This repository is my personal RTL (Register Transfer Level) playground for experimenting with digital design using Verilog and SystemVerilog. Here, I will add various projects as I explore and learn more about hardware design.
 
 ## Projects 
@@ -91,4 +94,4 @@ For questions or support, please contact the maintainer at benziong@mail.tau.ac.
 
 ---
 
-*More projects will be added as this playground grows!* 
+*More projects will be added as this playground grows!*


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow status badge to the `README.md` file, providing visibility into the build status of the repository.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R5): Added a GitHub Actions workflow status badge for the `master` branch to display the build status.